### PR TITLE
TOOLS 1541 update for server 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 - Bin Stats (`asinfo -v "bins/NAMESPACE_NAME"`)
 - SIndex Stats (`asinfo -v "sindex/NAMESPACE_NAME"`)
 - Latency Stats (`asinfo -v "latency:"`)
-- XDR Stats (`asinfo -v "statistics/xdr"`) & (`asinfo -v "get-stats:context=xdr;dc=DCN_NAME`) 5.0+
+- XDR Stats (`asinfo -v "statistics/xdr"`) & (`asinfo -v "get-stats:context=xdr;dc=DC_NAME`) 5.0+
 - Can use Aerospike Security accounts
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Compatibility
 =============
 Fully compatible with Aerospike Server 4.0 - 5.0.0.11. Although, only tested on 4.9.0.11 and 5.0.0.11.
 
-If you use a different server version it should work fine but could be missing a few metrics.
+If you use a server version outside of 4.0 - 5.0.0.11 it should work fine but could be missing a few metrics.
 
 Features
 ========

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 - Bin Stats (`asinfo -v "bins/NAMESPACE_NAME"`)
 - SIndex Stats (`asinfo -v "sindex/NAMESPACE_NAME"`)
 - Latency Stats (`asinfo -v "latency:"`)
-- XDR Stats (`asinfo -v "statistics/xdr"`) & (`asinfo -v "get-stats:context=xdr;dc=DC_NAME`) 5.0+
+- XDR Stats (`asinfo -v "dc/DC_NAME"`) & (`asinfo -v "get-stats:context=xdr;dc=DC_NAME`) 5.0+
 - Can use Aerospike Security accounts
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Aerospike plugin for collectd.
 
 Compatibility
 =============
-Fully compatible with Aerospike Server 4.* - 5.0.0.11
+Fully compatible with Aerospike Server 4.0 - 5.0.0.11. Although, only tested on 4.9.0.11 and 5.0.0.11.
 
-If you use a different server version you will likely have a few missing metrics but not many.
+If you use a different server version it should work fine but could be missing a few metrics.
 
 Features
 ========

--- a/README.md
+++ b/README.md
@@ -2,14 +2,21 @@ aerospike-collectd
 ====================
 Aerospike plugin for collectd.
 
-Version 1.0 is not compatible with previous 0.x releases due to metrics being renamed.
+Compatibility
+=============
+Fully compatible with Aerospike Server 4.* - 5.0.0.11
+
+If you use a different server version you will likely have a few missing metrics but not many.
 
 Features
 ========
 - Service Level Stats (`asinfo -v "statistics"`)
 - Namespace Stats (`asinfo -v "namespace/NAMESPACE_NAME"`)
+- Set Stats (`asinfo -v "sets/NAMESPACE_NAME/SET_NAME"`)
+- Bin Stats (`asinfo -v "bins/NAMESPACE_NAME"`)
+- SIndex Stats (`asinfo -v "sindex/NAMESPACE_NAME"`)
 - Latency Stats (`asinfo -v "latency:"`)
-- XDR Stats (`asinfo -v "statistics/xdr"`)
+- XDR Stats (`asinfo -v "statistics/xdr"`) & (`asinfo -v "get-stats:context=xdr;dc=DCN_NAME`) 5.0+
 - Can use Aerospike Security accounts
 
 Requirements

--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -758,7 +758,8 @@ class Plugin(object):
         if self.schema_path:
             collectd.info('Aerospike Plugin: schema %s' % self.schema_path)
             with open(self.schema_path) as schema_file:
-                self.schema = Schema(yaml.load(schema_file))
+                self.schema = Schema(
+                    yaml.load(schema_file, Loader=yaml.SafeLoader))
 
         self.initialized = True
 

--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -547,7 +547,6 @@ def sets(client, config, meta, emit):
         meta['timeouts'] += 1
     else:
         sets = parse(res, seq())
-        collectd.info('Failed to execute info "%s" - %s' % (req, res))
         for _set in sets:
             entries = parse(_set, seq(delim=':', entry=pair()))
             entries_dict = dict(

--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -525,6 +525,8 @@ def bins(client, config, meta, emit):
 
     try:
         res = client.info(req)
+        if res is None or len(res) == 0:
+            return
     except ClientError as e:
         collectd.warning('Failed to execute info "%s" - %s' % (req, e))
         meta['timeouts'] += 1
@@ -542,6 +544,8 @@ def sets(client, config, meta, emit):
 
     try:
         res = client.info(req)
+        if res is None or len(res) == 0:
+            return
     except ClientError as e:
         collectd.warning('Failed to execute info "%s" - %s' % (req, e))
         meta['timeouts'] += 1
@@ -562,6 +566,8 @@ def sindexes(client, config, meta, emit):
 
     try:
         res = client.info(req)
+        if res is None or len(res) == 0:
+            return
     except ClientError as e:
         collectd.warning('Failed to execute info "%s" - %s' % (req, e))
         meta['timeouts'] += 1

--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -468,11 +468,9 @@ def datacenters(client, config, meta, emit):
 
 # For the old DC metrics prior to version 5.0
 def datacenter(client, config, meta, emit, dc):
+    
+    dc_name = dc['DC_Name'] if 'DC_Name' in dc else dc['dc-name']
 
-    try:
-        dc_name = dc['DC_Name']
-    except:
-        dc_name = dc['dc-name']
     req = "dc/%s" % dc_name
     res = None
 

--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ------------------------------------------------------------------------------
 # Copyright 2012-2020 Aerospike, Inc.
 #

--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -340,7 +340,7 @@ class Schema(object):
                 val = 0
             else:
                 val = 1
-        if name == "cluster_key" or name == "cluster_principal" or name == "paxos_principal":
+        if name in {"cluster_key", "cluster_principal", "paxos_principal"}:
             val = int(val,16)
         return val
 
@@ -468,7 +468,7 @@ def datacenters(client, config, meta, emit):
 
 # For the old DC metrics prior to version 5.0
 def datacenter(client, config, meta, emit, dc):
-    
+
     dc_name = dc['DC_Name'] if 'DC_Name' in dc else dc['dc-name']
 
     req = "dc/%s" % dc_name
@@ -606,8 +606,7 @@ def sindexes(client, config, meta, emit):
     else:
         sindexes = parse(res, seq())
         for sidx in sindexes:
-            sidx = dict(parse(sidx,
-                                    seq(delim=':', entry=pair())))
+            sidx = dict(parse(sidx, seq(delim=':', entry=pair())))
             sindex(client, config, meta, emit, sidx)
 
 

--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # ------------------------------------------------------------------------------
-# Copyright 2012-2019 Aerospike, Inc.
+# Copyright 2012-2020 Aerospike, Inc.
 #
 # Portions may be licensed to Aerospike, Inc. under one or more contributor
 # license agreements.
@@ -17,8 +17,8 @@
 # ------------------------------------------------------------------------------
 
 __author__ = "Aerospike"
-__copyright__ = "Copyright 2019 Aerospike"
-__version__ = "2.0.0"
+__copyright__ = "Copyright 2020 Aerospike"
+__version__ = "3.0.0"
 
 import aerospike
 import collectd

--- a/aerospike_schema.yaml
+++ b/aerospike_schema.yaml
@@ -219,7 +219,7 @@ service:
     - free-pct-memory
     - free_dlog_pct        # renamed dlog_free_pct
     - heap_efficiency_pct
-    - process_cpu_pct      # new in 4.7
+    - process_cpu_pct
     - read_threads_avg_processing_time_pct        # renamed xdr_read_active_avg_pct
     - read_threads_avg_waiting_time_pct            # renamed xdr_read_idle_avg_pct
     - system_free_mem_pct
@@ -811,7 +811,9 @@ namespace:
     - xdr_write_timeout
 
 # ==============================================================================
-# Datacenter (XDR) specific metrics recorded per datacenter
+# Datacenter (XDR) specific metrics recorded per datacenter 
+# Note: As of server 5.0 XDR metrics have their own XDR context and all these
+# metrics are deprecated.
 # ------------------------------------------------------------------------------
 
 # inline comments indicate moved/renamed metrics starting with ASD 3.9+
@@ -834,7 +836,7 @@ datacenter:
     - dc_ship_inflight_objects
     - dc_ship_latency_avg
     - dc_state:CLUSTER_DOWN=0;CLUSTER_UP=1;CLUSTER_WINDOW_SHIP=2;CLUSTER_INACTIVE=3
-  
+
   bytes:
     - dc_ship_bytes
     - dc_esmt_bytes_shipped    # renamed dc_ship_bytes
@@ -854,6 +856,37 @@ datacenter:
     - est_ship_compression_pct
     - dc_ship_idle_avg_pct
     - dc_esmt_ship_avg_comp_pct
+
+
+# ==============================================================================
+# XDR specific metrics.  New as of server 5.0.  Some metrics are new while
+# others are renamed/moved from namespace
+# ------------------------------------------------------------------------------
+
+xdr:
+  
+  gauge:
+  - compression_ratio
+  - lag
+  - latency_ms
+  - recoveries_pending
+
+  operations:
+  - abandoned
+  - filtered_out
+  - hot_keys
+  - in_progress
+  - in_queue
+  - lap_us
+  - not_found
+  - recoveries
+  - retry_conn_reset
+  - retry_dest
+  - success
+  - throughput
+
+  percent:
+  - uncompressed_pct
 
 
 # ==============================================================================

--- a/aerospike_schema.yaml
+++ b/aerospike_schema.yaml
@@ -828,7 +828,7 @@ datacenter:
     - dc_http_locations
     - dc_http_good_locations
     - dc_latency_avg_ship    # renamed dc_ship_latency_avg
-    - dc_remote_ship_avg_sleepls |    # renamed dc_ship_idle_avg
+    - dc_remote_ship_avg_sleep    # renamed dc_ship_idle_avg
     - dc_open_conn                  # renamed dc_as_open_conn
     - dc_recs_inflight        # renamed dc_ship_inflight_objects
     - dc_size                 # renamed dc_as_size

--- a/aerospike_schema.yaml
+++ b/aerospike_schema.yaml
@@ -128,10 +128,16 @@ service:
   gauge:
     - aggr_scans_failed     # Moved to NS scan_aggr_error
     - aggr_scans_succeded    # Moved to NS scan_aggr_complete
-    - cluster_clock_skew
+    - batch_index_proto_compression_ratio
+    - cluster_clock_skew     # Renames to cluster_clock_skew_ms 4.0.0.4
+    - cluster_clock_skew_ms
     - cluster_clock_skew_stop_writes_sec
     - cluster_key
+    - cluster_min_compatibility_id
+    - cluster_max_compatibility_id
     - cluster_size
+    - cluster_generation
+    - cluster_principal
     - uptime
     - batch_queue
     - batch_tree_count
@@ -169,6 +175,8 @@ service:
     - partition_object_count
     - partition_ref_count
     - partition_replica
+    - paxos_principal
+    - pmem_compression_ratio
     - proxy_in_progress
     - queue                # renamed tsvc_queue
     - record_locks
@@ -177,13 +185,14 @@ service:
     - stat_evicted_objects_time
     - sub-records     # renamed to sub_objects
     - sub_objects
+    - time_since_rebalance
     - tombstones
     - total_recs_dlog
     - transaction_queue_used    # renamed xdr_read_txnq_used
     - tree_gc_queue
     - tsvc_queue
-    - used_recs_dlog    # renamed dlog_used_objects
     - tree_count
+    - used_recs_dlog    # renamed dlog_used_objects
     - waiting_transactions
     - query_long_queue_size
     - query_short_queue_size
@@ -204,14 +213,19 @@ service:
     - system_swapping
 
   percent:
+    - batch_index_proto_uncompressed_pct
     - dlog_free_pct
     - free-pct-disk
     - free-pct-memory
     - free_dlog_pct        # renamed dlog_free_pct
     - heap_efficiency_pct
+    - process_cpu_pct      # new in 4.7
     - read_threads_avg_processing_time_pct        # renamed xdr_read_active_avg_pct
-    - read_threads_avg_watiing_time_pct            # renamed xdr_read_idle_avg_pct
+    - read_threads_avg_waiting_time_pct            # renamed xdr_read_idle_avg_pct
     - system_free_mem_pct
+    - system_total_cpu_pct
+    - system_user_cpu_pct
+    - system_kernel_cpu_pct
     - transaction_queue_used_pct        # renamed xdr_read_txnq_used_pct
     - xdr_read_active_avg_pct
     - xdr_read_idle_avg_pct
@@ -235,13 +249,14 @@ service:
     - basic_scans_failed    # moved to NS scan_basic_error
     - basic_scans_succeeded    # moved to NS scan_basic_complete
     - batch_error
+    - batch_index_delay
     - batch_index_initiate
     - batch_index_complete
     - batch_index_timeout
     - batch_index_error
+    - batch_index_created_buffers
     - batch_index_unused_buffers
     - batch_index_huge_buffers
-    - batch_index_created_buffers
     - batch_index_destroyed_buffers
     - batch_initiate
     - batch_timeout
@@ -257,6 +272,7 @@ service:
     - early_tsvc_client_error
     - early_tsvc_from_proxy_batch_sub_error
     - early_tsvc_from_proxy_error
+    - early_tsvc_ops_sub_error
     - early_tsvc_udf_sub_error
     - err_duplicate_proxy_request
     - err_out_of_space    
@@ -297,7 +313,7 @@ service:
     - local_recs_error        # renamed xdr_read_error
     - local_recs_fetch_avg_latency        # renamed xdr_read_latency_avg
     - local_recs_fetched        # renamed xdr_read_success
-    - local_recs_notfound        # renamed xdr_read_not_found
+    - local_recs_notfound        # renamed xdr_read_notfound
     - migrate_msgs_recv
     - migrate_msgs_sent
     - migrate_num_incoming_accepted
@@ -329,7 +345,7 @@ service:
     - query_lookup_avg_rec_count    # moved to NS
     - query_lookup_err        # moved to NS query_lookup_error
     - query_lookups    # moved to NS
-    - query_lookup_success        # moved to NS 
+    - query_lookup_success        # moved to NS
     - query_reqs                # moved to NS
     - query_short_queue_full    # moved to NS
     - query_short_reqs        # moved to NS
@@ -356,6 +372,7 @@ service:
     - sindex_gc_list_deletion_time
     - sindex_gc_locktimedout
     - sindex_gc_objects_validated
+    - sindex_gc_retries
     - sindex_ucgarbage_found
     - stat_cluster_key_err_ack_dup_trans_reenqueue
     - stat_cluster_key_err_ack_rw_trans_reenqueue
@@ -435,7 +452,7 @@ service:
     - xdr_hotkey_skip
     - xdr_queue_overflow_error
     - xdr_read_error
-    - xdr_read_not_found
+    - xdr_read_notfound
     - xdr_read_reqq_used
     - xdr_read_respq_used
     - xdr_read_success
@@ -444,6 +461,7 @@ service:
     - xdr_ship_bytes
     - xdr_ship_delete_success
     - xdr_ship_destination_error
+    - xdr_ship_destination_permanent_error
     - xdr_ship_inflight_objects
     - xdr_ship_fullrecord
     - xdr_ship_outstanding_objects
@@ -472,6 +490,7 @@ namespace:
     - current_time
     - dead_partitions
     - defrag_q
+    - device_compression_ratio
     - effective_replication_factor
     - evict_void_time
     - free_wblocks
@@ -492,6 +511,8 @@ namespace:
     - migrate_rx_partitions_initial
     - migrate-rx-partitions-remaining
     - migrate_rx_partitions_remaining
+    - migrate_signals_active
+    - migrate_signals_remaining
     - migrate-tx-instance-count
     - migrate_tx_instance_count
     - migrate-tx-partitions-active
@@ -502,19 +523,31 @@ namespace:
     - migrate_tx_partitions_initial
     - migrate-tx-partitions-remaining
     - migrate_tx_partitions_remaining
+    - migrate_tx_partitions_lead_remaining
+    - nodes_quiesced
+    - non_replica_objects
     - non-expirable-objects
     - non_expirable_objects
+    - n_nodes_quiesced      # renamed nodes_quiesced
     - nsup-cycle-duration
     - nsup_cycle_duration
     - objects
     - obj-size-hist-max
     - obj_size_hist_max
+    - pmem_compression_ratio
     - prole-objects
     - prole_objects
     - prole-sub-objects
     - prole_sub_objects
+    - query_proto_compression_ratio
+    - record_proto_compression_ratio
+    - scan_proto_compression_ratio
     - shadow_write_q
     - smd_evict_void_time
+    - tombstones
+    - master_tombstones
+    - non_replica_tombstones
+    - prole_tombstones
     - unavailable_partitions
     - write_q
     # Configs
@@ -528,11 +561,15 @@ namespace:
     - data-used-bytes-memory    # renamed memory_used_data_bytes
     - device_total_bytes
     - device_used_bytes
+    - index_flash_used_bytes
+    - index_pmem_used_bytes
     - index-used-bytes-memory    # renamed memory_used_index_bytes
     - memory_used_bytes
     - memory_used_data_bytes
     - memory_used_index_bytes
     - memory_used_sindex_bytes
+    - pmem_total_bytes
+    - pmem_used_bytes
     - sindex-used-bytes-memory        # moved to NS memory_used_sindex_bytes
     - total-bytes-disk
     - total-bytes-memory
@@ -542,8 +579,11 @@ namespace:
 
   boolean:
     - clock_skew_stop_writes
+    - effective_is_quiesced
+    - effective_prefer_uniform_balance
     - hwm-breached
     - hwm_breached
+    - pending_quiesce
     - stop_writes
 
   percent:
@@ -553,10 +593,17 @@ namespace:
     - device_available_pct
     - device_free_pct
     - free-pct-disk
-    - memory_free_pct
     - free-pct-memory
-    - nsup-cycle-sleep-pct  
+    - index_flash_used_pct
+    - index_pmem_used_pct
+    - memory_free_pct
+    - nsup-cycle-sleep-pct
     - nsup_cycle_sleep_pct
+    - pmem_available_pct
+    - pmem_free_pct
+    - query_proto_uncompressed_pct
+    - record_proto_uncompressed_pct
+    - scan_proto_uncompressed_pct
 
   operations:
     - appeals_records_exonerated
@@ -564,12 +611,14 @@ namespace:
     - batch_sub_proxy_error
     - batch_sub_proxy_timeout
     - batch_sub_read_error
+    - batch_sub_read_filtered_out
     - batch_sub_read_not_found
     - batch_sub_read_success
     - batch_sub_read_timeout
     - batch_sub_tsvc_error
     - batch_sub_tsvc_timeout
     - client_delete_error
+    - client_delete_filtered_out
     - client_delete_not_found
     - client_delete_success
     - client_delete_timeout
@@ -581,6 +630,7 @@ namespace:
     - client_proxy_error
     - client_proxy_timeout
     - client_read_error
+    - client_read_filtered_out
     - client_read_not_found
     - client_read_success
     - client_read_timeout
@@ -588,12 +638,15 @@ namespace:
     - client_tsvc_timeout
     - client_udf_complete
     - client_udf_error
+    - client_udf_filtered_out
     - client_udf_timeout
     - client_write_error
+    - client_write_filtered_out
     - client_write_success
     - client_write_timeout
     - defrag_reads
     - defrag_writes
+    - deleted_last_bin
     - evicted-objects
     - evicted_objects
     - evict_ttl
@@ -604,12 +657,16 @@ namespace:
     - fail_record_too_big
     - fail_xdr_forbidden
     - from_proxy_batch_sub_read_error
+    - from_proxy_read_filtered_out
+    - from_proxy_batch_sub_read_filtered_out
     - from_proxy_batch_sub_read_not_found
     - from_proxy_batch_sub_read_success
     - from_proxy_batch_sub_read_timeout
     - from_proxy_batch_sub_tsvc_error
     - from_proxy_batch_sub_tsvc_timeout
-    - from_proxy_delete_error
+    - from_proxy_write_filtered_out
+    - from_proxy_delete_error  
+    - from_proxy_delete_filtered_out
     - from_proxy_delete_not_found
     - from_proxy_delete_success
     - from_proxy_delete_timeout
@@ -625,11 +682,13 @@ namespace:
     - from_proxy_tsvc_timeout
     - from_proxy_udf_complete
     - from_proxy_udf_error
+    - from_proxy_udf_filtered_out
     - from_proxy_udf_timeout
     - from_proxy_write_error
     - from_proxy_write_success
     - from_proxy_write_timeout
     - geo_region_query_cells
+    - geo_region_query_count            # as of 7/28/20 not yet returned from asdb.  It is renamed to ..._reqs which was deprecated
     - geo_region_query_falsepos
     - geo_region_query_points
     - geo_region_query_reqs
@@ -649,6 +708,12 @@ namespace:
     - migrate_records_skipped
     - migrate-records-transmitted
     - migrate_records_transmitted
+    - ops_sub_tsvc_error
+    - ops_sub_tsvc_timeout
+    - ops_sub_write_error
+    - ops_sub_write_success
+    - ops_sub_write_timeout
+    - ops_sub_write_filtered_out
     - query_abort
     - query_agg
     - query_agg_abort
@@ -662,6 +727,7 @@ namespace:
     - query_lookup_abort
     - query_lookup_avg_rec_count
     - query_lookup_err
+    - query_lookup_error
     - query_lookup_success
     - query_lookups
     - query_reqs
@@ -670,11 +736,14 @@ namespace:
     - query_success
     - query_udf_bg_failure
     - query_udf_bg_success
+    - query_ops_bg_success
+    - query_ops_bg_failure
     - scan_aggr_abort
     - re_repl_error
     - re_repl_success
     - re_repl_timeout
     - retransmit_all_read_dup_res
+    - retransmit_all_batch_sub_dup_res
     - retransmit_all_delete_dup_res
     - retransmit_all_delete_repl_write
     - retransmit_all_sub_dup_res
@@ -682,23 +751,42 @@ namespace:
     - retransmit_all_udf_repl_write
     - retransmit_all_write_dup_res
     - retransmit_all_write_repl_write
+    - retransmit_client_read_dup_res
+    - retransmit_client_write_dup_res
+    - retransmit_client_write_repl_write
+    - retransmit_client_delete_dup_res
+    - retransmit_client_delete_repl_write
+    - retransmit_client_udf_dup_res
+    - retransmit_client_udf_repl_write
+    - retransmit_batch_sub_dup_res
+    - retransmit_ops_sub_dup_res
+    - retransmit_ops_sub_repl_write
+    - retransmit_udf_sub_dup_res
+    - retransmit_udf_sub_repl_write
+    - retransmit_nsup_repl_write
     - scan_aggr_complete
     - scan_aggr_error
     - scan_basic_abort
     - scan_basic_complete
     - scan_basic_error
+    - scan_ops_bg_complete
+    - scan_ops_bg_error
+    - scan_ops_bg_abort
     - scan_udf_bg_abort
     - scan_udf_bg_complete
     - scan_udf_bg_error
     - set-deleted-objects
     - set_deleted_objects
     - set-evicted-objects
+    - truncate_lut
+    - truncated_records
     - udf_sub_lang_delete_success
     - udf_sub_lang_error
     - udf_sub_lang_read_success
     - udf_sub_lang_write_success
     - udf_sub_udf_complete
     - udf_sub_udf_error
+    - udf_sub_udf_filtered_out
     - udf_sub_udf_timeout
     - udf_sub_tsvc_error
     - udf_sub_tsvc_timeout
@@ -730,14 +818,18 @@ namespace:
 datacenter:
   
   gauge:
+    - dc_as_open_conn
+    - dc_as_size
     - dc_timelag
     - dc_err_ship_client    # renamed dc_ship_source_error
     - dc_err_ship_server    # renamed dc_ship_destination_error
+    - dc_http_locations
+    - dc_http_good_locations
     - dc_latency_avg_ship    # renamed dc_ship_latency_avg
-    - dc_remote_ship_avg_sleepa    # renamed dc_ship_idle_avg
-    - dc_open_conn
+    - dc_remote_ship_avg_sleepls |    # renamed dc_ship_idle_avg
+    - dc_open_conn                  # renamed dc_as_open_conn
     - dc_recs_inflight        # renamed dc_ship_inflight_objects
-    - dc_size
+    - dc_size                 # renamed dc_as_size
     - dc_ship_idle_avg
     - dc_ship_inflight_objects
     - dc_ship_latency_avg
@@ -762,3 +854,69 @@ datacenter:
     - est_ship_compression_pct
     - dc_ship_idle_avg_pct
     - dc_esmt_ship_avg_comp_pct
+
+
+# ==============================================================================
+# Bin specific metrics.  Context is different for each namespace.
+# ------------------------------------------------------------------------------
+
+bins:
+
+  gauge:
+    - bin_names_quota
+    - bin_names
+
+
+# ==============================================================================
+# set specific metrics.  Context is different for each (namespace, set) pair.
+# ------------------------------------------------------------------------------
+
+sets:
+
+  gauge:
+    - objects
+    - tombstones
+
+  operations:
+    - truncate_lut
+
+  bytes:
+    - memory_data_bytes
+
+
+# ==============================================================================
+# sindex specific metrics.  Context is different for each (namespace, set) pair.
+# ------------------------------------------------------------------------------
+
+sindex:
+
+  gauge:
+    - entries
+    - keys
+    - loadtime
+    - query_agg_avg_rec_count
+    - query_agg_avg_record_size
+    - query_avg_rec_count
+    - query_avg_record_size
+    - query_lookup_avg_rec_count
+    - query_lookup_avg_record_size
+
+  bytes:
+    - ibtr_memory_used
+    - nbtr_memory_used
+    - si_accounted_memory
+
+
+  operations:
+    - delete_error
+    - delete_success
+    - query_agg
+    - query_lookups
+    - query_reqs
+    - stat_gc_recs
+    - stat_gc_time
+    - write_error
+    - write_success
+  
+  percent:
+    - load_pct

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyyaml
 collectd
-aerospike==3.7.1
+aerospike==3.10.0


### PR DESCRIPTION
JIRA: https://aerospike.atlassian.net/browse/PROD-1192

Final updates of the effort to catch collectd up to server 5.0. 

The server (in theory) should be fully compatible with 4.0 - 5.011 and include any metric available.  This was done by making the aerospike_schema.yaml a superset of the metrics available on any particular server version.  Although, it has only been tested on 4.9.0.11 and 5.0.0.10.  

Main things accomplished:
- Add new xdr metrics to the schema.
- Add info() calls to get-stats to retrieve xdr metrics
- Update readme with more up to date info.

Things not changed: 
- latency metrics
- cluster metrics