### PR TITLE
Allow 5.0+ Cluster without XDR to send metrics

### DIFF
--- a/aerospike_plugin.py
+++ b/aerospike_plugin.py
@@ -21,6 +21,7 @@ __copyright__ = "Copyright 2020 Aerospike"
 __version__ = "3.0.0"
 
 import aerospike
+from aerospike.exception import ServerError
 import collectd
 import os
 import re
@@ -437,7 +438,10 @@ def datacenters(client, config, meta, emit):
         # If this fails, then it is either not EE edition or it is a pre 5.0 version.
         collectd.debug('Failed to execute info "%s" - %s' % (req, e))
         meta['timeouts'] += 1
-
+    except ServerError as e:
+        # If this fails, cluster may not have xdr enabled at all.
+        collectd.info('Failed to execute info "%s" - %s' % (req, e))
+        meta['timeouts'] += 1
     else:
         dcs = dict(parse(res, seq(entry=pair())))
 


### PR DESCRIPTION
After Upgrading a Cluster from version 4.9 to 5.1, and updating to latest collectd setup from this repo (develop branch),
This Fatal Error may be encountered if the cluster doesn't use XDR at all:

> collectd[32670]: Unhandled python exception in read callback: ServerError: (1L, 'XDR-not-configured, 127.0.0.1:..., False)
> collectd[32670]: Traceback (most recent call last):
> collectd[32670]: File "/opt/collectd-plugins/aerospike_plugin.py", line 863, in read
> collectd[32670]: reader(self.client, config, meta, self.emit)
> collectd[32670]: File "/opt/collectd-plugins/aerospike_plugin.py", line 433, in datacenters
> collectd[32670]: res = client.info(req)
> collectd[32670]: File "/opt/collectd-plugins/aerospike_plugin.py", line 283, in info
> collectd[32670]: res = self.asClient.info_node(request, self.host, policy=read_policies)
> collectd[32670]: ServerError: (1L, 'XDR-not-configured, 127.0.0.1:3000', 'src/main/client/info_node.c', 177, False)
> collectd[32670]: read-function of plugin `python.aerospike_plugin' failed. Will suspend it for 120.000 seconds.

In order to fix this I have added Exception handling for ANY 'ServerError' aside from the existing 'ClientError', and assumed it is due to XDR not being present, logged the error, and kept publishing all other available metrics