### PR TITLE
add missing batch ops/s

### DIFF
--- a/aerospike_schema.yaml
+++ b/aerospike_schema.yaml
@@ -89,6 +89,7 @@ latency:
     - reads_tps
     - write_tps
     - writes_master_tps
+    - batch-index_tps
     - proxy_tps
     - udf_tps
     - query_tps


### PR DESCRIPTION
While monitoring an all flash enterprise cluster with collectd, 
I diagnosed with Aerospike support a missing metric in schema yaml file:
batch-index_tps

the metric is reported by aerospike server, and is parsed correctly by the python collectd plugin,
however since it was missing from the schema, the metric was dropped, and only pct_ms is available.

This commit adds the tps for batch-index